### PR TITLE
Added a synonym for the symbol Circled Plus

### DIFF
--- a/loc/en/symbols/2200.txt
+++ b/loc/en/symbols/2200.txt
@@ -147,7 +147,7 @@
 2292: Square Original of or Equal To
 2293: Square Cap
 2294: Square Cup
-2295: Circled Plus: direct sum , vector pointing into page
+2295: Circled Plus: direct sum , vector pointing into page , XOR sum
 2296: Circled Minus: symmetric difference
 2297: Circled Times: tensor product , vector pointing into page
 2298: Circled Division Slash: ban, disable

--- a/loc/fr/symbols/2200.txt
+++ b/loc/fr/symbols/2200.txt
@@ -147,7 +147,7 @@
 2292: Original carré ou égal à
 2293: Chapeau carré
 2294: Coupe carrée
-2295: Plus cerclé: somme directe , vecteur pointant vers l'intérieur de la page
+2295: Plus cerclé: somme directe , vecteur pointant vers l'intérieur de la page , somme XOR
 2296: Moins cerclé: différence symétrique
 2297: Multiplié par cerclé: produit tensoriel , vecteur pointant vers l'intérieur de la page
 2298: Barre oblique de division cerclée


### PR DESCRIPTION
The symbol Circled Plus (U+2295 ⊕) is used for the XOR sum, but you can't find it if you search the word “XOR”.
This commit resolve this an add the synonym “XOR sum” for the English and French.